### PR TITLE
Adds a missing "var" keyword to updateMarkers

### DIFF
--- a/paper-slider.html
+++ b/paper-slider.html
@@ -307,7 +307,8 @@ To change the slider secondary progress bar color:
     },
 
     updateMarkers: function() {
-      this.markers = [], l = (this.max - this.min) / this.step;
+      this.markers = [];
+      var l = (this.max - this.min) / this.step;
       if (!this.snaps && l > this.maxMarkers) {
         return;
       }


### PR DESCRIPTION
The author forgot "var", so the "l" var is declared on the global scope. Apart from being wrong, it's dangerous for anyone using compiled/obfuscated JS, where it may be overwriting an obfuscated variable (common because it's only a single letter). I came across the bug when I noticed it overwriting what was supposed to be an alias for the window object in my compiled code.

Simply adding a var keyword redeclares it in the local scope, fixing the problem.
